### PR TITLE
fix: fail closed for account-scoped publish credentials

### DIFF
--- a/src/opencmo/llm.py
+++ b/src/opencmo/llm.py
@@ -63,6 +63,16 @@ _ENV_PRIORITY_KEYS = frozenset({
     "OPENAI_BASE_URL",
     "OPENCMO_MODEL_DEFAULT",
 })
+_ACCOUNT_SCOPED_SECRET_KEYS = frozenset({
+    "REDDIT_CLIENT_ID",
+    "REDDIT_CLIENT_SECRET",
+    "REDDIT_USERNAME",
+    "REDDIT_PASSWORD",
+    "TWITTER_API_KEY",
+    "TWITTER_API_SECRET",
+    "TWITTER_ACCESS_TOKEN",
+    "TWITTER_ACCESS_SECRET",
+})
 
 # ---------------------------------------------------------------------------
 # ContextVar — per-request key isolation (asyncio Task-local)
@@ -178,7 +188,12 @@ def get_key(name: str, default: str | None = None) -> str | None:
     if val:
         return val
 
-    # 3. os.environ
+    # 3. Sensitive account-scoped secrets must fail closed to avoid
+    # cross-account credential bleed through process-global env.
+    if name in _ACCOUNT_SCOPED_SECRET_KEYS:
+        return default
+
+    # 4. os.environ
     val = os.environ.get(name)
     if val:
         return val
@@ -222,13 +237,17 @@ async def get_key_async(name: str, default: str | None = None) -> str | None:
         except Exception:
             pass
 
-    # 4. For core router defaults, prefer env/.env over persisted DB settings.
+    # 4. Sensitive account-scoped secrets must not fall through to system/env.
+    if name in _ACCOUNT_SCOPED_SECRET_KEYS:
+        return default
+
+    # 5. For core router defaults, prefer env/.env over persisted DB settings.
     if name in _ENV_PRIORITY_KEYS:
         val = os.environ.get(name)
         if val:
             return val
 
-    # 5. System fallback (admin account → legacy settings table)
+    # 6. System fallback (admin account → legacy settings table)
     try:
         from opencmo import storage
         val = await storage.get_system_setting(name)
@@ -237,7 +256,7 @@ async def get_key_async(name: str, default: str | None = None) -> str | None:
     except Exception:
         pass  # DB may not be initialized yet
 
-    # 6. os.environ
+    # 7. os.environ
     val = os.environ.get(name)
     if val:
         return val

--- a/tests/test_settings_multitenant.py
+++ b/tests/test_settings_multitenant.py
@@ -176,6 +176,23 @@ def test_get_key_async_reads_per_account_via_db_when_snapshot_empty(isolated_db)
     assert value == "alice_db_only"
 
 
+def test_publish_credentials_do_not_fallback_to_env_or_system(isolated_db, monkeypatch):
+    """Tenant-missing publish creds must not resolve from global/system fallbacks."""
+    admin_id = asyncio.run(storage.get_admin_account_id())
+    _, tenant_account = _seed_account(email="tenant@example.test", name="Tenant")
+    asyncio.run(storage.set_account_setting(admin_id, "REDDIT_CLIENT_ID", "admin-cid"))
+    monkeypatch.setenv("REDDIT_CLIENT_ID", "env-cid")
+
+    acct_token = llm.set_current_account_id(tenant_account)
+    snap_token = llm.set_current_account_settings({})
+    try:
+        assert asyncio.run(llm.get_key_async("REDDIT_CLIENT_ID")) is None
+        assert llm.get_key("REDDIT_CLIENT_ID") is None
+    finally:
+        llm.reset_current_account_settings(snap_token)
+        llm.reset_current_account_id(acct_token)
+
+
 # ---------------------------------------------------------------------------
 # System fallback / legacy table
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Close an authorization gap where account-scoped publish credentials (Reddit/Twitter) could be resolved from admin/system rows or the process environment, allowing a non-admin tenant to publish using another account's credentials.
- Ensure publish-provider secrets are strictly isolated to the request or the owning account to prevent cross-tenant credential reuse.

### Description
- Add `_ACCOUNT_SCOPED_SECRET_KEYS` in `src/opencmo/llm.py` listing publish-related secrets (REDDIT_*, TWITTER_*).
- Harden `llm.get_key` and `llm.get_key_async` so that if a requested key is in `_ACCOUNT_SCOPED_SECRET_KEYS` and it is not present in the request ContextVar, the account snapshot, or the account DB row, the resolver returns `default` (fails closed) instead of falling through to system/admin DB or `os.environ`.
- Add a regression test `test_publish_credentials_do_not_fallback_to_env_or_system` in `tests/test_settings_multitenant.py` that asserts a tenant without Reddit credentials cannot obtain them from admin account settings or environment.

### Testing
- Ran `pytest -q tests/test_llm.py tests/test_settings_multitenant.py` (without `PYTHONPATH`) which failed to collect due to import path issues in this environment (ModuleNotFoundError for `opencmo`).
- Ran `PYTHONPATH=src pytest -q tests/test_llm.py tests/test_settings_multitenant.py`, which executed but many async-marked tests failed because the test environment is missing async test plugins/dependencies (e.g. `pytest-asyncio`), so the full suite could not be validated here.
- Ran a focused invocation for the new/related multitenant tests (`PYTHONPATH=src pytest -q tests/test_settings_multitenant.py -k "publish_credentials_do_not_fallback_to_env_or_system or get_key_reads_account_snapshot_set_by_middleware"`), but execution was skipped in this environment due to test prerequisites (FastAPI/other runtime test deps) not being available; the new regression test is present and will run in CI where the project test deps are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e603b42483308b68b554460fd270)