### PR TITLE
fix: prevent admin privilege escalation via signup

### DIFF
--- a/src/opencmo/storage/accounts.py
+++ b/src/opencmo/storage/accounts.py
@@ -177,6 +177,7 @@ async def get_user_account(user_id: int) -> dict | None:
 
 async def create_user_with_account(email: str, password: str, name: str = "") -> tuple[dict, dict]:
     normalized = (email or "").strip().lower()
+    admin_email = os.environ.get("OPENCMO_ADMIN_EMAIL", "hello@aidcmo.com").strip().lower()
     if not is_valid_email(normalized):
         raise ValueError("invalid_email")
     if len(password or "") < MIN_PASSWORD_LENGTH:
@@ -189,6 +190,8 @@ async def create_user_with_account(email: str, password: str, name: str = "") ->
     try:
         existing = await db.execute("SELECT id, password_hash FROM users WHERE email = ?", (normalized,))
         row = await existing.fetchone()
+        if row and row[1] == "!unusable" and normalized == admin_email:
+            raise ValueError("email_exists")
         if row and row[1] != "!unusable":
             raise ValueError("email_exists")
 
@@ -206,7 +209,7 @@ async def create_user_with_account(email: str, password: str, name: str = "") ->
                     normalized,
                     hash_password(password),
                     name.strip(),
-                    "admin" if normalized == os.environ.get("OPENCMO_ADMIN_EMAIL", "hello@aidcmo.com").strip().lower() else "user",
+                    "user",
                 ),
             )
             user_id = int(cursor.lastrowid)


### PR DESCRIPTION
### Motivation
- The public signup flow could claim a bootstrap admin row (created with `password_hash == "!unusable"`) or implicitly create the configured admin email as an admin, allowing unauthenticated privilege escalation on fresh/unclaimed deployments. 

### Description
- In `create_user_with_account` added a guard that treats an existing `!unusable` admin row as taken and raises `ValueError("email_exists")` for signups that try to claim `OPENCMO_ADMIN_EMAIL` by matching the normalized email. 
- Removed the implicit admin role assignment for self-service signups so inserted users always get role `"user"` rather than being promoted to `"admin"` when they match `OPENCMO_ADMIN_EMAIL`. 
- The change is contained to `src/opencmo/storage/accounts.py` and preserves normal signup/account creation and the explicit bootstrap logic that runs at DB init. 

### Testing
- Attempted to run focused tests with `pytest tests/test_trial_platform.py::test_signup_login_me_and_logout` and `pytest tests/test_trial_platform.py::test_admin_summary_requires_admin tests/test_trial_platform.py::test_admin_account_actions_update_and_disable_access`, but the test runs failed to collect/execute because the environment in this container is missing runtime dependencies (`aiosqlite`) and the test runner could not import the `opencmo` package. 
- No automated test failures were observed in-repo as a result of the code edits because the test environment could not run; the change was verified by local code inspection and by confirming the updated lines in `src/opencmo/storage/accounts.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c2ddf6cc8330b715fa4f19e487ac)