### PR TITLE
fix: restrict Docker default network exposure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,5 @@ RUN playwright install-deps chromium \
 COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
 VOLUME ["/data"]
 ENV OPENCMO_DB_PATH=/data/data.db
-ENV OPENCMO_WEB_HOST=0.0.0.0
 EXPOSE 8080
 CMD ["opencmo-web"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ services:
   opencmo:
     build: .
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
+    environment:
+      - OPENCMO_WEB_HOST=0.0.0.0
     volumes:
       - opencmo_data:/data
     env_file:


### PR DESCRIPTION
### Motivation

- Prevent insecure default Docker behavior that made the unauthenticated OpenCMO API reachable on all host interfaces by removing image-level all-interface binding and making compose defaults localhost-only.

### Description

- Remove the image-level `ENV OPENCMO_WEB_HOST=0.0.0.0` from `Dockerfile` so the container image no longer forces binding to all interfaces.
- Change `docker-compose.yml` to publish the port on the loopback interface with `127.0.0.1:8080:8080` so the service is not exposed to the LAN by default.
- Add `OPENCMO_WEB_HOST=0.0.0.0` to the compose service `environment` so container-side binding still allows host access for local development without exposing the host to other networks.

### Testing

- Attempted to validate the compose configuration with `docker compose config`, but the environment lacks Docker so that check failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d48c0422bc8330805e7b0eff14c7f0)