### PR TITLE
fix: bind docker compose port to localhost by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   opencmo:
     build: .
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     volumes:
       - opencmo_data:/data
     env_file:


### PR DESCRIPTION
### Motivation
- The Docker setup exposed the unauthenticated local API by setting `OPENCMO_WEB_HOST=0.0.0.0` in the image and publishing port `8080` in `docker-compose.yml`, which makes the API reachable on all host interfaces by default.

### Description
- Update `docker-compose.yml` to change the ports mapping from `8080:8080` to `127.0.0.1:8080:8080` so the web UI/API remains accessible from the host only and is not exposed to external interfaces by default.

### Testing
- Ran `git diff --check` which completed with no errors.
- Attempted `docker compose config` to validate the composed config but it could not be executed in this environment because `docker` is not installed (command-not-found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cfbb39ba208330b7fd73f7d0703b35)