### PR TITLE
fix: stop blanking public pages (homepage white screen)

### DIFF
--- a/src/opencmo/web/app.py
+++ b/src/opencmo/web/app.py
@@ -886,9 +886,14 @@ def _replace_metadata(rendered: str, replacements: list[tuple[str, str]]) -> str
 
 
 def _replace_static_site_copy(rendered: str, static_copy: str) -> str:
+    # Match the real element, which carries translate="yes" — NOT the bare
+    # `<main id="static-site-copy">` mentioned inside the head comment. Matching
+    # the comment text would extend `.*?</main>` from inside the comment to the
+    # real </main>, swallowing the closing `-->`, the module <script>, and
+    # <body> — leaving an unterminated comment that blanks the whole page.
     return re.sub(
-        r'<main id="static-site-copy">.*?</main>',
-        static_copy,
+        r'<main id="static-site-copy" translate="yes"[^>]*>.*?</main>',
+        lambda _match: static_copy,
         rendered,
         count=1,
         flags=re.DOTALL,


### PR DESCRIPTION
## Root cause
`_replace_static_site_copy` used the regex `<main id="static-site-copy">.*?</main>` (DOTALL). That bare tag **first appears as literal text inside the head comment** documenting the static-copy / Chrome-Translate mechanism. The match therefore ran *from inside the comment* to the real `</main>`, swallowing:
- the comment's closing `-->` (→ unterminated comment → browser swallows the rest of the document)
- the module `<script src="/assets/index-*.js">` (→ React never boots)
- the `<body>` tag

So every public route (`/`, `/en/*`, `/blog/*`, `/console`) served a **blank white page**. `/app/` was spared only because it skips static-copy replacement.

## Fix
Anchor the regex to the **real** element (which carries `translate="yes"`), so the in-comment mention no longer matches. Use a callable replacement to avoid backreference interpretation in the HTML payload.

## Verified
- TestClient: `/`, `/console`, `/en/services`, `/blog/*` → 200, contain module script + `#root` + `<body>`, comment balanced.
- Headless browser render of backend-served `/` HTML: **`#root` mounts, React renders** (no blank page).