### PR TITLE
test: fix spa_catchall blog fixtures to match #31 regex (green CI)

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1892,7 +1892,7 @@ def test_spa_catchall_blog_route_injects_public_metadata(client, tmp_path):
             <meta name="twitter:description" content="home desc" />
           </head>
           <body>
-            <main id="static-site-copy"><h1>Home</h1></main>
+            <main id="static-site-copy" translate="yes"><h1>Home</h1></main>
           </body>
         </html>
         """
@@ -1927,7 +1927,7 @@ def test_spa_catchall_zh_blog_route_injects_localized_metadata(client, tmp_path)
             <script type="application/ld+json">{}</script>
           </head>
           <body>
-            <main id="static-site-copy"><h1>Home</h1></main>
+            <main id="static-site-copy" translate="yes"><h1>Home</h1></main>
           </body>
         </html>
         """


### PR DESCRIPTION
## Problem
`main` CI is red. PR #31 (homepage white-screen fix) tightened the static-copy regex to require `translate="yes"` so it matches the real `<main id="static-site-copy" translate="yes">` element instead of the bare `<main id="static-site-copy">` mentioned inside the head comment (matching the comment swallowed the closing `-->` + module `<script>` → blank page).

The two blog-route test fixtures still used the old `<main id="static-site-copy">` form, so the regex no longer matched → static copy not injected → 2 failing tests:
- `test_spa_catchall_blog_route_injects_public_metadata`
- `test_spa_catchall_zh_blog_route_injects_localized_metadata`

## Fix
Update both fixtures to the real `translate="yes"` format. No production code change.

## Verified
`pytest tests/test_web.py` → 76 passed, 3 skipped (was 2 failed).