### PR TITLE
fix: load Google Fonts non-blocking (prevent blank page where the CDN is blocked)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -46,7 +46,13 @@
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Non-blocking webfont load: a render-blocking Google Fonts stylesheet can
+         leave the page blank for many seconds where fonts.googleapis.com is
+         throttled/null-routed (e.g. mainland China). media="print" + onload lets
+         the page paint immediately with fallback fonts and upgrade once loaded;
+         <noscript> keeps a blocking copy for crawlers / no-JS clients. -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap"></noscript>
     <script>
       document.documentElement.classList.add("js");
     </script>


### PR DESCRIPTION
## Problem
The homepage `<head>` loads Google Fonts via a **render-blocking** `<link rel="stylesheet" href="https://fonts.googleapis.com/...">`. Where that host is throttled / null-routed (mainland China), the request hangs for tens of seconds and the browser holds back first paint — the page is **fully blank** even though the JS bundle loaded and React mounted. This matches a reported white screen (PC Chrome, China + VPN, fully blank, other overseas sites fine).

## Fix (`frontend/index.html`)
Load the webfont stylesheet non-blocking: `media="print" onload="this.media='all'"`, with a `<noscript>` blocking fallback for crawlers / no-JS clients. The page paints immediately with system fallback fonts and upgrades to the webfonts once (if) they arrive.

No JS/CSS bundle change — `index-*.js` hashes unchanged.