### PR TITLE
feat: add debuggable deep search tracing

### DIFF
--- a/src/opencmo/agents/blog.py
+++ b/src/opencmo/agents/blog.py
@@ -4,6 +4,7 @@ from opencmo.agents.prompt_contracts import build_prompt
 from opencmo.config import get_model
 from opencmo.tools.blog_writer import research_blog_topic
 from opencmo.tools.crawl import crawl_website
+from opencmo.tools.deep_search import deep_search
 from opencmo.tools.search import web_search
 
 blog_expert = Agent(
@@ -45,7 +46,7 @@ Every article should read like a strong product-marketing asset: it should attra
 ### Mode B: Full Article (when user asks for complete article/blog post/full article)
 
 1. **Research phase**: Use `research_blog_topic` to gather competing content data and insights
-2. Optionally use `web_search` / `crawl_website` for supplementary research
+2. Optionally use `deep_search`, `web_search`, or `crawl_website` for supplementary research
 3. Write a complete **2000+ word** markdown article with:
    - Engaging introduction (150-200 words) — hook with a problem or surprising insight
    - 5-7 H2 sections, each 200-400 words
@@ -79,6 +80,6 @@ Every article should read like a strong product-marketing asset: it should attra
 - The reader should leave with a usable insight even if they never click the product link
 """,
     ),
-    tools=[web_search, crawl_website, research_blog_topic],
+    tools=[web_search, crawl_website, deep_search, research_blog_topic],
     model=get_model("blog"),
 )

--- a/src/opencmo/agents/cmo.py
+++ b/src/opencmo/agents/cmo.py
@@ -29,6 +29,7 @@ from opencmo.tools.competitor import analyze_competitor
 from opencmo.tools.content_frequency import check_content_frequency
 from opencmo.tools.crawl import crawl_website
 from opencmo.tools.cta_audit import audit_landing_page_cta
+from opencmo.tools.deep_search import deep_search
 from opencmo.tools.graph_intel import get_competitive_landscape
 from opencmo.tools.gsc import check_search_console
 from opencmo.tools.keyword_suggest import suggest_keywords
@@ -204,7 +205,7 @@ Your job is to think like a real marketing leader, not a generic assistant. Conv
    - This is critical: for multi-channel, do NOT handoff — use the tool versions so you can collect all outputs and present a cohesive summary
    - The research brief creates a Campaign Run that tracks all generated content as artifacts
 
-4. **Web Search**: Use `web_search` for competitive research, market trends, keyword research, or any real-time information needs.
+4. **Deep Search / Web Search**: Use `deep_search` when research needs a transparent Search -> Read -> Search loop, especially for competitor/market research where traceability matters. Use `web_search` for quick real-time lookups.
 
 5. **Competitor Analysis**: Use `analyze_competitor` to get structured data about a competitor's product, then use insights to differentiate content.
 
@@ -244,6 +245,7 @@ When the user asks for "全平台" or "comprehensive" distribution, prioritize i
     ),
     tools=[
         crawl_website,
+        deep_search,
         web_search,
         analyze_competitor,
         generate_research_brief,

--- a/src/opencmo/tools/__init__.py
+++ b/src/opencmo/tools/__init__.py
@@ -2,6 +2,7 @@ from .blog_writer import research_blog_topic
 from .community import analyze_community_patterns, fetch_discussion_detail, scan_community
 from .competitor import analyze_competitor
 from .crawl import crawl_website
+from .deep_search import deep_search
 from .email_report import send_email_report
 from .geo import scan_geo_visibility
 from .publishers import publish_to_reddit, publish_to_twitter
@@ -13,6 +14,7 @@ from .trends import get_geo_trends, get_seo_trends
 
 __all__ = [
     "crawl_website",
+    "deep_search",
     "web_search",
     "audit_page_seo",
     "analyze_competitor",

--- a/src/opencmo/tools/crawl.py
+++ b/src/opencmo/tools/crawl.py
@@ -6,6 +6,7 @@ from agents import function_tool
 from crawl4ai import AsyncWebCrawler
 
 from opencmo.tools.browser_pool import browser_slot
+from opencmo.tools.deep_search_trace import get_cached, record_trace, set_cached
 
 
 def _extract_markdown(result) -> str:
@@ -60,6 +61,25 @@ async def fetch_url_content(
     tavily_extract_depth: str = "advanced",
 ) -> tuple[str, str]:
     """Fetch page content with Tavily-first fallback to crawl4ai."""
+    payload = {
+        "url": url,
+        "max_chars": max_chars,
+        "tavily_extract_depth": tavily_extract_depth,
+    }
+    cached = get_cached("crawl_website", "fetch_url_content", payload)
+    if isinstance(cached, dict) and "content" in cached and "source" in cached:
+        content = str(cached["content"])
+        source = str(cached["source"])
+        record_trace(
+            tool="crawl_website",
+            action="fetch_url_content",
+            payload=payload,
+            provider=source,
+            cache_hit=True,
+            output=content,
+        )
+        return content, source
+
     from opencmo.tools.tavily_helper import tavily_extract
 
     content = await tavily_extract(
@@ -86,6 +106,19 @@ async def fetch_url_content(
     if max_chars is not None and len(content) > max_chars:
         content = content[:max_chars]
 
+    set_cached(
+        "crawl_website",
+        "fetch_url_content",
+        payload,
+        {"content": content, "source": source},
+    )
+    record_trace(
+        tool="crawl_website",
+        action="fetch_url_content",
+        payload=payload,
+        provider=source,
+        output=content,
+    )
     return content, source
 
 

--- a/src/opencmo/tools/deep_search.py
+++ b/src/opencmo/tools/deep_search.py
@@ -1,0 +1,208 @@
+"""Debuggable deep-search tool with traced planning loops."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+from agents import function_tool
+
+from opencmo.tools.deep_search_trace import record_trace, summarize_text
+
+
+@dataclass
+class DeepSearchStep:
+    depth: int
+    query: str
+    thought: str
+    search_summary: str = ""
+    read_url: str | None = None
+    read_source: str | None = None
+    read_summary: str = ""
+    error: str | None = None
+    children: list["DeepSearchStep"] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "depth": self.depth,
+            "query": self.query,
+            "thought": self.thought,
+            "search_summary": self.search_summary,
+            "read_url": self.read_url,
+            "read_source": self.read_source,
+            "read_summary": self.read_summary,
+            "error": self.error,
+            "children": [child.to_dict() for child in self.children],
+        }
+
+
+def _breakpoints_enabled() -> bool:
+    return os.getenv("OPENCMO_DEEP_SEARCH_BREAKPOINTS", "").strip().lower() in {"1", "true", "on", "yes"}
+
+
+def _maybe_cli_breakpoint(step: DeepSearchStep) -> str | None:
+    """Return an override query, stop marker, or None.
+
+    The breakpoint is intentionally opt-in and TTY-only so web/API deployments never
+    block waiting for terminal input.
+    """
+    if not _breakpoints_enabled() or not sys.stdin.isatty():
+        return None
+
+    prompt = (
+        f"\n[OpenCMO deep_search breakpoint depth={step.depth}]\n"
+        f"Thought: {step.thought}\n"
+        f"Next query: {step.query}\n"
+        "Press Enter to continue, type 'stop' to end, or type a replacement query: "
+    )
+    response = input(prompt).strip()
+    if not response:
+        return None
+    if response.lower() in {"stop", "quit", "exit"}:
+        return "__STOP__"
+    return response
+
+
+def _extract_first_url(search_text: str) -> str | None:
+    for line in search_text.splitlines():
+        candidate = line.strip()
+        if candidate.startswith(("http://", "https://")):
+            return candidate
+    return None
+
+
+def _next_query(original_query: str, step: DeepSearchStep) -> str:
+    if step.read_url:
+        return f"{original_query} alternatives pricing competitors"
+    return f"{original_query} official site case studies"
+
+
+def _format_tree(steps: list[DeepSearchStep]) -> str:
+    parts: list[str] = []
+    for step in steps:
+        parts.append(
+            "\n".join(
+                [
+                    f"## Step {step.depth}: {step.query}",
+                    f"Thought: {step.thought}",
+                    f"Search summary: {step.search_summary or 'No search summary.'}",
+                    f"Read URL: {step.read_url or 'None'}",
+                    f"Read source: {step.read_source or 'None'}",
+                    f"Read summary: {step.read_summary or 'No page read.'}",
+                    f"Error: {step.error or 'None'}",
+                ]
+            )
+        )
+    return "\n\n".join(parts)
+
+
+async def run_deep_search(query: str, *, max_depth: int = 2, read_chars: int = 4000) -> dict[str, Any]:
+    """Run a traced Search -> Read -> Search loop and return structured state."""
+    max_depth = max(1, min(max_depth, 5))
+    read_chars = max(500, min(read_chars, 20000))
+
+    steps: list[DeepSearchStep] = []
+    current_query = query
+
+    for depth in range(1, max_depth + 1):
+        step = DeepSearchStep(
+            depth=depth,
+            query=current_query,
+            thought=(
+                "Start broad, inspect the strongest source, then refine the query "
+                "based on what the page reveals."
+            ),
+        )
+
+        override = _maybe_cli_breakpoint(step)
+        if override == "__STOP__":
+            step.error = "Stopped by CLI breakpoint."
+            steps.append(step)
+            break
+        if override:
+            step.query = override
+            current_query = override
+
+        try:
+            from opencmo.tools.tavily_helper import tavily_search
+
+            results = await tavily_search(current_query, max_results=3, search_depth="basic")
+            if results:
+                search_lines = []
+                for result in results:
+                    search_lines.append(f"{result.title}\n{result.url}\n{result.snippet}")
+                search_text = "\n\n".join(search_lines)
+            else:
+                search_text = ""
+            step.search_summary = summarize_text(search_text)
+            step.read_url = _extract_first_url(search_text)
+            record_trace(
+                tool="deep_search",
+                action="search",
+                payload={"query": current_query, "depth": depth, "max_results": 3},
+                provider="tavily",
+                output=search_text,
+                metadata={"tree": [item.to_dict() for item in steps + [step]]},
+            )
+        except Exception as exc:
+            step.error = f"Search failed: {exc}"
+            record_trace(
+                tool="deep_search",
+                action="search",
+                payload={"query": current_query, "depth": depth, "max_results": 3},
+                provider="tavily",
+                error=str(exc),
+                metadata={"tree": [item.to_dict() for item in steps + [step]]},
+            )
+            steps.append(step)
+            break
+
+        if step.read_url:
+            try:
+                from opencmo.tools.crawl import fetch_url_content
+
+                content, source = await fetch_url_content(step.read_url, max_chars=read_chars)
+                step.read_source = source
+                step.read_summary = summarize_text(content, max_chars=900)
+                record_trace(
+                    tool="deep_search",
+                    action="read",
+                    payload={"url": step.read_url, "depth": depth, "read_chars": read_chars},
+                    provider=source,
+                    output=content,
+                    metadata={"tree": [item.to_dict() for item in steps + [step]]},
+                )
+            except Exception as exc:
+                step.error = f"Read failed: {exc}"
+                record_trace(
+                    tool="deep_search",
+                    action="read",
+                    payload={"url": step.read_url, "depth": depth, "read_chars": read_chars},
+                    error=str(exc),
+                    metadata={"tree": [item.to_dict() for item in steps + [step]]},
+                )
+
+        steps.append(step)
+        if depth < max_depth:
+            current_query = _next_query(query, step)
+
+    return {
+        "query": query,
+        "max_depth": max_depth,
+        "steps": [step.to_dict() for step in steps],
+        "summary": _format_tree(steps),
+    }
+
+
+@function_tool
+async def deep_search(query: str, max_depth: int = 2) -> str:
+    """Run a debuggable Search -> Read -> Search research loop.
+
+    Args:
+        query: The market, competitor, product, or topic to research.
+        max_depth: Number of search/read iterations. Clamped to 1-5.
+    """
+    result = await run_deep_search(query, max_depth=max_depth)
+    return result["summary"]

--- a/src/opencmo/tools/deep_search_trace.py
+++ b/src/opencmo/tools/deep_search_trace.py
@@ -1,0 +1,139 @@
+"""Structured tracing and optional caching for deep-search tool calls."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_PREVIEW_CHARS = 600
+
+
+def _is_disabled(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"0", "false", "off", "no"}
+
+
+def tracing_enabled() -> bool:
+    return not _is_disabled(os.getenv("OPENCMO_DEEP_SEARCH_TRACE"))
+
+
+def cache_enabled() -> bool:
+    return os.getenv("OPENCMO_DEEP_SEARCH_CACHE", "").strip().lower() in {"1", "true", "on", "yes"}
+
+
+def _state_dir() -> Path:
+    custom_dir = os.getenv("OPENCMO_DEEP_SEARCH_DIR")
+    if custom_dir:
+        return Path(custom_dir).expanduser()
+    return Path.home() / ".opencmo" / "deep_search"
+
+
+def trace_path() -> Path:
+    return _state_dir() / "trace.jsonl"
+
+
+def cache_path() -> Path:
+    return _state_dir() / "cache.json"
+
+
+def _json_default(value: Any) -> str:
+    return str(value)
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=_json_default)
+
+
+def cache_key(tool: str, action: str, payload: dict[str, Any]) -> str:
+    raw = _stable_json({"tool": tool, "action": action, "payload": payload})
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def summarize_text(text: Any, *, max_chars: int = DEFAULT_PREVIEW_CHARS) -> str:
+    if text is None:
+        return ""
+    collapsed = " ".join(str(text).split())
+    if len(collapsed) <= max_chars:
+        return collapsed
+    return collapsed[:max_chars] + "..."
+
+
+def record_trace(
+    *,
+    tool: str,
+    action: str,
+    payload: dict[str, Any],
+    provider: str | None = None,
+    cache_hit: bool = False,
+    output: Any = None,
+    error: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Append one structured deep-search event to the JSONL trace."""
+    event = {
+        "id": str(uuid.uuid4()),
+        "ts": time.time(),
+        "tool": tool,
+        "action": action,
+        "provider": provider,
+        "cache_hit": cache_hit,
+        "payload": payload,
+        "output_preview": summarize_text(output),
+        "output_chars": len(str(output)) if output is not None else 0,
+        "error": error,
+        "metadata": metadata or {},
+    }
+    if not tracing_enabled():
+        return event
+
+    path = trace_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
+    return event
+
+
+def _load_cache() -> dict[str, Any]:
+    path = cache_path()
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def get_cached(tool: str, action: str, payload: dict[str, Any]) -> Any | None:
+    if not cache_enabled():
+        return None
+    key = cache_key(tool, action, payload)
+    entry = _load_cache().get(key)
+    if not isinstance(entry, dict):
+        return None
+    return entry.get("value")
+
+
+def set_cached(tool: str, action: str, payload: dict[str, Any], value: Any) -> None:
+    if not cache_enabled():
+        return
+    path = cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = _load_cache()
+    data[cache_key(tool, action, payload)] = {
+        "stored_at": time.time(),
+        "tool": tool,
+        "action": action,
+        "payload": payload,
+        "value": value,
+    }
+    tmp_path = path.with_suffix(".tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, sort_keys=True, indent=2)
+    tmp_path.replace(path)

--- a/src/opencmo/tools/search.py
+++ b/src/opencmo/tools/search.py
@@ -5,6 +5,7 @@ import logging
 from agents import function_tool
 
 from opencmo.tools.browser_pool import browser_slot
+from opencmo.tools.deep_search_trace import get_cached, record_trace, set_cached
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,19 @@ async def web_search(query: str) -> str:
     Args:
         query: The search query string.
     """
+    payload = {"query": query, "max_results": 5}
+    cached = get_cached("web_search", "search", payload)
+    if cached is not None:
+        record_trace(
+            tool="web_search",
+            action="search",
+            payload=payload,
+            provider="cache",
+            cache_hit=True,
+            output=cached,
+        )
+        return str(cached)
+
     try:
         from opencmo.tools.tavily_helper import tavily_search
 
@@ -24,8 +38,25 @@ async def web_search(query: str) -> str:
             parts = []
             for result in results:
                 parts.append(f"### {result.title}\n{result.url}\n\n{result.snippet}")
-            return "\n\n---\n\n".join(parts)
+            output = "\n\n---\n\n".join(parts)
+            set_cached("web_search", "search", payload, output)
+            record_trace(
+                tool="web_search",
+                action="search",
+                payload=payload,
+                provider="tavily",
+                output=output,
+                metadata={"result_count": len(results)},
+            )
+            return output
     except Exception as exc:
+        record_trace(
+            tool="web_search",
+            action="search",
+            payload=payload,
+            provider="tavily",
+            error=str(exc),
+        )
         logger.debug("Tavily search failed, trying fallback: %s", exc)
 
     # 2. Fallback: OpenAI built-in web search (native provider only)
@@ -43,8 +74,23 @@ async def web_search(query: str) -> str:
                 None, json.dumps({"query": query}),
             )
             if result:
+                set_cached("web_search", "search", payload, result)
+                record_trace(
+                    tool="web_search",
+                    action="search",
+                    payload=payload,
+                    provider="openai_web_search",
+                    output=result,
+                )
                 return result
         except Exception as exc:
+            record_trace(
+                tool="web_search",
+                action="search",
+                payload=payload,
+                provider="openai_web_search",
+                error=str(exc),
+            )
             logger.debug("OpenAI WebSearchTool fallback failed: %s", exc)
 
     # 3. Final fallback: crawl4ai Google scrape
@@ -58,6 +104,24 @@ async def web_search(query: str) -> str:
             async with AsyncWebCrawler() as crawler:
                 result = await crawler.arun(url=url)
         content = _extract_markdown(result)
-        return content[:4000] if content else "No search results found."
+        output = content[:4000] if content else "No search results found."
+        set_cached("web_search", "search", payload, output)
+        record_trace(
+            tool="web_search",
+            action="search",
+            payload=payload,
+            provider="crawl4ai_google",
+            output=output,
+        )
+        return output
     except Exception as e:
-        return f"Web search failed: {e}. Try using other available tools instead."
+        output = f"Web search failed: {e}. Try using other available tools instead."
+        record_trace(
+            tool="web_search",
+            action="search",
+            payload=payload,
+            provider="crawl4ai_google",
+            output=output,
+            error=str(e),
+        )
+        return output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,9 @@ def _isolate_external_provider_keys(monkeypatch):
     token = llm.set_request_keys({})
     for key in EXTERNAL_PROVIDER_KEYS:
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENCMO_DEEP_SEARCH_TRACE", "0")
+    monkeypatch.delenv("OPENCMO_DEEP_SEARCH_CACHE", raising=False)
+    monkeypatch.delenv("OPENCMO_DEEP_SEARCH_DIR", raising=False)
     try:
         yield
     finally:

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -89,3 +89,37 @@ async def test_fetch_url_content_falls_back_to_html_metadata_when_markdown_is_em
     assert "Page title: Coze" in content
     assert "Meta description: AI agent workspace for teams" in content
     assert "Open Graph description: Build agents quickly" in content
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_content_uses_deep_search_cache(tmp_path, monkeypatch):
+    """Shared content fetch should reuse opt-in deep-search cache entries."""
+    from opencmo.tools import crawl as crawl_module
+    import opencmo.tools.deep_search_trace as trace
+
+    monkeypatch.setenv("OPENCMO_DEEP_SEARCH_CACHE", "1")
+    monkeypatch.setenv("OPENCMO_DEEP_SEARCH_TRACE", "1")
+    monkeypatch.setenv("OPENCMO_DEEP_SEARCH_DIR", str(tmp_path))
+
+    payload = {
+        "url": "https://example.com",
+        "max_chars": None,
+        "tavily_extract_depth": "advanced",
+    }
+    trace.set_cached(
+        "crawl_website",
+        "fetch_url_content",
+        payload,
+        {"content": "# Cached page", "source": "tavily"},
+    )
+
+    mock_extract = AsyncMock(side_effect=AssertionError("live extraction should not run"))
+
+    with patch("opencmo.tools.tavily_helper.tavily_extract", mock_extract, create=True):
+        content, source = await crawl_module.fetch_url_content("https://example.com")
+
+    assert content == "# Cached page"
+    assert source == "tavily"
+    mock_extract.assert_not_called()
+    trace_lines = trace.trace_path().read_text(encoding="utf-8").splitlines()
+    assert any('"cache_hit": true' in line for line in trace_lines)

--- a/tests/test_deep_search.py
+++ b/tests/test_deep_search.py
@@ -1,0 +1,73 @@
+"""Tests for the debuggable deep-search planning loop."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import importlib
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_run_deep_search_traces_search_read_loop(tmp_path, monkeypatch):
+    import opencmo.tools.deep_search_trace as trace
+    from opencmo.tools.deep_search import run_deep_search
+
+    monkeypatch.setenv("OPENCMO_DEEP_SEARCH_TRACE", "1")
+    monkeypatch.setenv("OPENCMO_DEEP_SEARCH_DIR", str(tmp_path))
+
+    search_mock = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                title="Example",
+                url="https://example.com/pricing",
+                snippet="Pricing and competitor context",
+            )
+        ]
+    )
+    fetch_mock = AsyncMock(return_value=("# Pricing page\nEnterprise details", "tavily"))
+
+    monkeypatch.setattr("opencmo.tools.tavily_helper.tavily_search", search_mock)
+    monkeypatch.setattr("opencmo.tools.crawl.fetch_url_content", fetch_mock)
+
+    result = await run_deep_search("Example pricing", max_depth=2)
+
+    assert result["max_depth"] == 2
+    assert len(result["steps"]) == 2
+    assert result["steps"][0]["read_url"] == "https://example.com/pricing"
+    assert "Step 1: Example pricing" in result["summary"]
+    assert "Read source: tavily" in result["summary"]
+    assert search_mock.await_count == 2
+    assert fetch_mock.await_count == 2
+
+    events = [line for line in trace.trace_path().read_text(encoding="utf-8").splitlines()]
+    assert any('"tool": "deep_search"' in line and '"action": "search"' in line for line in events)
+    assert any('"tool": "deep_search"' in line and '"action": "read"' in line for line in events)
+    assert any('"tree"' in line for line in events)
+
+
+@pytest.mark.asyncio
+async def test_run_deep_search_clamps_depth(monkeypatch):
+    from opencmo.tools.deep_search import run_deep_search
+
+    search_mock = AsyncMock(return_value=[])
+    monkeypatch.setattr("opencmo.tools.tavily_helper.tavily_search", search_mock)
+
+    result = await run_deep_search("OpenCMO", max_depth=99)
+
+    assert result["max_depth"] == 5
+    assert len(result["steps"]) == 5
+
+
+def test_cli_breakpoint_can_override_query(monkeypatch):
+    deep_search_module = importlib.import_module("opencmo.tools.deep_search")
+    from opencmo.tools.deep_search import DeepSearchStep
+
+    monkeypatch.setenv("OPENCMO_DEEP_SEARCH_BREAKPOINTS", "1")
+    monkeypatch.setattr(deep_search_module.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "replacement query")
+
+    override = deep_search_module._maybe_cli_breakpoint(
+        DeepSearchStep(depth=1, query="original", thought="test")
+    )
+
+    assert override == "replacement query"

--- a/tests/test_deep_search_trace.py
+++ b/tests/test_deep_search_trace.py
@@ -1,0 +1,42 @@
+"""Tests for debuggable deep-search tracing and caching."""
+
+import json
+
+
+def test_record_trace_writes_jsonl(tmp_path, monkeypatch):
+    import opencmo.tools.deep_search_trace as trace
+
+    monkeypatch.setenv("OPENCMO_DEEP_SEARCH_TRACE", "1")
+    monkeypatch.setenv("OPENCMO_DEEP_SEARCH_DIR", str(tmp_path))
+
+    event = trace.record_trace(
+        tool="web_search",
+        action="search",
+        payload={"query": "OpenCMO competitors"},
+        provider="tavily",
+        output="A long but useful search result",
+    )
+
+    lines = trace.trace_path().read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    stored = json.loads(lines[0])
+    assert stored["id"] == event["id"]
+    assert stored["tool"] == "web_search"
+    assert stored["action"] == "search"
+    assert stored["payload"]["query"] == "OpenCMO competitors"
+    assert stored["provider"] == "tavily"
+    assert stored["output_preview"] == "A long but useful search result"
+
+
+def test_cache_round_trip_requires_opt_in(tmp_path, monkeypatch):
+    import opencmo.tools.deep_search_trace as trace
+
+    monkeypatch.setenv("OPENCMO_DEEP_SEARCH_DIR", str(tmp_path))
+    payload = {"query": "OpenCMO"}
+
+    trace.set_cached("web_search", "search", payload, "cached result")
+    assert trace.get_cached("web_search", "search", payload) is None
+
+    monkeypatch.setenv("OPENCMO_DEEP_SEARCH_CACHE", "1")
+    trace.set_cached("web_search", "search", payload, "cached result")
+    assert trace.get_cached("web_search", "search", payload) == "cached result"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -9,11 +9,13 @@ def test_imports():
     from opencmo.tools import (
         check_keyword_ranking,
         crawl_website,
+        deep_search,
         publish_to_reddit,
     )
     # Just verify they exist
     assert cmo_agent is not None
     assert crawl_website is not None
+    assert deep_search is not None
     assert check_keyword_ranking is not None
     assert publish_to_reddit is not None
 
@@ -23,6 +25,8 @@ def test_cmo_has_tools_and_handoffs():
 
     assert len(cmo_agent.tools) > 0, "CMO should have tools"
     assert len(cmo_agent.handoffs) > 0, "CMO should have handoffs"
+    tool_names = [t.name for t in cmo_agent.tools if hasattr(t, "name")]
+    assert "deep_search" in tool_names
 
 
 def test_cmo_has_as_tool_wrappers():
@@ -78,6 +82,13 @@ def test_all_experts_have_instructions():
     ]:
         assert agent.instructions, f"{agent.name} missing instructions"
         assert len(agent.instructions) > 50, f"{agent.name} instructions too short"
+
+
+def test_blog_expert_has_deep_search_tool():
+    from opencmo.agents import blog_expert
+
+    tool_names = [t.name for t in blog_expert.tools if hasattr(t, "name")]
+    assert "deep_search" in tool_names
 
 
 def test_platform_experts_keep_explicit_deliverable_labels():


### PR DESCRIPTION
## Summary

- Adds a debuggable deepsearch tool that runs a bounded Search - Read - Search loop with maxdepth protection.
- - Adds structured JSONL tracing for search crawl read cache-hit provider payload output preview errors and exploration-tree metadata.
- - Adds opt-in local JSON caching for search/crawl results via OPENCMODEEPSEARCHCACHE=1.
- - Adds opt-in CLI breakpoints for deep search via OPENCMODEEPSEARCHBREAKPOINTS=1 guarded by TTY detection so web/API deployments do not block.
- - Wires deepsearch into the CMO Agent and Blog SEO Expert.
Closes #1 
## Verification

- env PYTHONPATH=src python -m pytest tests/testdeepsearchtrace.py tests/testdeepsearch.py tests/testcrawl.py tests/testsmoke.py - 25 passed
- - env PYTHONPATH=src python -m pytest - 670 passed 3 skipped
## Notes

- Tracing is enabled by default and can be disabled with OPENCMODEEPSEARCHTRACE=0.
- - Cache reuse is opt-in to avoid stale research results in production.